### PR TITLE
Hotfix(empty buffer)

### DIFF
--- a/lua/base/utils/status/component.lua
+++ b/lua/base/utils/status/component.lua
@@ -288,8 +288,8 @@ function M.treesitter(opts)
 end
 
 --- A function to build a set of children components for an LSP section
----@param opts? table options for configuring lsp progress and client_name providers and the overall padding
----@return table # The Heirline component table
+-- @param opts? table options for configuring lsp progress and client_name providers and the overall padding
+-- @return table # The Heirline component table
 -- @usage local heirline_component = require("base.utils.status").component.lsp()
 function M.lsp(opts)
   opts = extend_tbl({
@@ -298,7 +298,7 @@ function M.lsp(opts)
       padding = { right = 1 },
       update = {
         "User",
-        pattern = "BaseLspProgress",
+        pattern = { "LspProgressUpdate", "LspRequest" },
         callback = vim.schedule_wrap(function() vim.cmd.redrawstatus() end),
       },
     },

--- a/lua/base/utils/status/condition.lua
+++ b/lua/base/utils/status/condition.lua
@@ -1,4 +1,4 @@
---- ### base Status Conditions
+--- ### base status conditions
 --
 -- Statusline related condition functions to use with Heirline
 --
@@ -112,7 +112,13 @@ function M.aerial_available() return package.loaded["aerial"] end
 -- @usage local heirline_component = { provider = "Example Provider", condition = require("base.utils.status").condition.lsp_attached }
 function M.lsp_attached(bufnr)
   if type(bufnr) == "table" then bufnr = bufnr.bufnr end
-  return next(vim.lsp.get_active_clients { bufnr = bufnr or 0 }) ~= nil
+
+  -- Hotfix: Stack trace on empty buffer
+  -- Not setting the lsp status for files without a filetype we avoid the error
+  if vim.bo.filetype == '' then return end
+
+  local is_attached = next(vim.lsp.get_active_clients { bufnr = bufnr or 0 }) ~= nil
+  return is_attached
 end
 
 --- A condition function if treesitter is in use


### PR DESCRIPTION
I will make this patch more beautiful later, but for not it does what it is supposed to do. If a file don't have a filetype, it won't try to show the lsp status on the status bar anymore.