### PR TITLE
improvement(heirlne) 

### DIFF
--- a/lua/plugins/2-ui.lua
+++ b/lua/plugins/2-ui.lua
@@ -241,7 +241,7 @@ return {
   --  https://github.com/rebelot/heirline.nvim
   {
     "rebelot/heirline.nvim",
-    event = "VeryLazy",
+    event = "BufEnter",
     opts = function()
       local status = require "base.utils.status"
       return {


### PR DESCRIPTION
Actually, with 634af9c05cd53c2424192ad22219e4316b623ed1 we can use BufEnter instead of VeryLazy, which prevents heirline to load slightly slower in those border case scenarios. Thank you mehalter from AstroNvim for coming up with the improvement.