### PR TITLE
fix wrong how to use AI command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ Yes, 100%. This is not necessary, but we strongly recommend you to launch Normal
 
 * **How can I disable the animations?** You can delete the plugin [mini.animate](https://github.com/echasnovski/mini.animate). In case you only want to disable some animations look into the plugin docs.
 
-* **How can I use `Ask chatgpt`?** On your operative system, set the next env var. You can get an API key from chatgpt's website.
+* **How can I use `Ask chatgpt`?** On your operative system, set the next env var. You can get an API key from [chatgpt's website](https://platform.openai.com/account/api-keys)
 
 ```sh
-CHATGPT_API_KEY="my_key_here"
+OPENAI_API_KEY="my_key_here"
 ```
-
+ckeck how to set env var for [lunix](https://www.freecodecamp.org/news/how-to-set-an-environment-variable-in-linux/), [windows](https://phoenixnap.com/kb/windows-set-environment-variable), [mac](https://phoenixnap.com/kb/set-environment-variable-mac)
 * **What scenarios are not covered by this distro?**
   * **Kubernetes**: We do not provide a kubernetes plugin. But we recommend using friendly-snippets, to quickly write code, and [overseer.nvim](https://github.com/stevearc/overseer.nvim) to run kubernetes commands from inside nvim without having to wait for the server response.
   * **e2e testing**: We do not provide an e2e plugin. But we do provide the :TestNodejsE2e command you can customize on [/lua/base/3-autocmds.lua](https://github.com/Zeioth/NormalNvim/blob/main/lua/base/3-autocmds.lua) along with all the other testing commands. You can also rename the commands to anything you want in case you don't use nodejs.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Yes, 100%. This is not necessary, but we strongly recommend you to launch Normal
 ```sh
 OPENAI_API_KEY="my_key_here"
 ```
-ckeck how to set env var for [lunix](https://www.freecodecamp.org/news/how-to-set-an-environment-variable-in-linux/), [windows](https://phoenixnap.com/kb/windows-set-environment-variable), [mac](https://phoenixnap.com/kb/set-environment-variable-mac)
+
 * **What scenarios are not covered by this distro?**
   * **Kubernetes**: We do not provide a kubernetes plugin. But we recommend using friendly-snippets, to quickly write code, and [overseer.nvim](https://github.com/stevearc/overseer.nvim) to run kubernetes commands from inside nvim without having to wait for the server response.
   * **e2e testing**: We do not provide an e2e plugin. But we do provide the :TestNodejsE2e command you can customize on [/lua/base/3-autocmds.lua](https://github.com/Zeioth/NormalNvim/blob/main/lua/base/3-autocmds.lua) along with all the other testing commands. You can also rename the commands to anything you want in case you don't use nodejs.


### PR DESCRIPTION
neural use env var $OPENAI_API_KEY instead of $CHATGPT_API_KEY check (https://github.com/dense-analysis/neural) therefore I fix command and few URLs that will make it easy for user to use Ask chatgpt function.