### PR TITLE
change(spectre): We now ship `fd` instead of `rg` as search backend, …

### DIFF
--- a/lua/plugins/1-base-behaviors.lua
+++ b/lua/plugins/1-base-behaviors.lua
@@ -226,8 +226,8 @@ return {
     opts = {
       default = {
         find = {
-          -- pick one of item in find_engine [ ag, rg, ripgrep ]
-          cmd = "rg",
+          -- pick one of item in find_engine [ fd, rg ]
+          cmd = "fd",
           options = {}
         },
         replace = {


### PR DESCRIPTION
…as it is less likely to show unwanted behaviors.