### PR TITLE
Freeze plugin versions → Compiler.nvim `v3.3.1` fixes the Typescript …

### DIFF
--- a/lua/lazy_snapshot.lua
+++ b/lua/lazy_snapshot.lua
@@ -9,7 +9,7 @@ return {
   { "NvChad/nvim-colorizer.lua", commit = "dde3084106a70b9a79d48f426f6d6fec6fd203f7" },
   { "Shatur/neovim-session-manager", commit = "df544e17798dd0e6e33ecf0991dfde9174367837" },
   { "Zeioth/NormalSnippets", commit = "e91dbace3e221ee58de39d852c93ceca166f05c3" },
-  { "Zeioth/compiler.nvim", commit = "6ce5bfaeb9422cca562272807879954d1bd1fde5" },
+  { "Zeioth/compiler.nvim", version = "^3" },
   { "Zeioth/dooku.nvim", commit = "6b463d3cb568c4830cfdfd7d0ea17c15ff1d005e" },
   { "Zeioth/markmap.nvim", commit = "3befc2a54c2448a16c30c1c7762aab263f22946a" },
   { "Zeioth/project.nvim", commit = "3d30a4ddaf0f0c30892fb2f36fa4669499d7e6db" },


### PR DESCRIPTION
…and Javascript compiler.