### PR TITLE
Remove duplicate entry from Lazy

### DIFF
--- a/lua/lazy_snapshot.lua
+++ b/lua/lazy_snapshot.lua
@@ -84,7 +84,6 @@ return {
   { "rebelot/heirline.nvim", commit = "03cff30d7e7d3ba6fdc00925f015822f79cef908" },
   { "rouge8/neotest-rust", commit = "a9cd2ed69d6930a33bd97765fee49b0e13d7d7d0" },
   { "s1n7ax/nvim-window-picker", version = "^2" },
-  { "s1n7ax/nvim-window-picker", version = "^2" },
   { "saadparwaiz1/cmp_luasnip", commit = "18095520391186d634a0045dacaa346291096566" },
   { "sidlatau/neotest-dart", commit = "178c62282d5fa82f3d564b3c256b4d316804da67" },
   { "skywind3000/gutentags_plus", commit = "21cc952f006cd335b6bd571e1af0bdee50b2b4b1" },


### PR DESCRIPTION
Was reviewing the repo and came across a duplicate in `lazy_snapshot.lua`.

Making this PR to fix it.
