### PR TITLE
`distroupdate.nvim` updated to `v0.4.0`.

### DIFF
--- a/lua/base/4-mappings.lua
+++ b/lua/base/4-mappings.lua
@@ -282,7 +282,7 @@ end
 -- nvim updater
 maps.n["<leader>pa"] =
 { "<cmd>NvimUpdatePlugins<cr>", desc = "Update Plugins and Mason" }
-maps.n["<leader>pD"] = { "<cmd>NvimUpdateConfig<cr>", desc = "Distro update" }
+maps.n["<leader>pD"] = { "<cmd>NvimDistroUpdate<cr>", desc = "Distro update" }
 maps.n["<leader>pv"] = { "<cmd>NvimVersion<cr>", desc = "Distro version" }
 maps.n["<leader>pc"] = { "<cmd>NvimChangelog<cr>", desc = "Distro Changelog" }
 

--- a/lua/base/utils/lsp.lua
+++ b/lua/base/utils/lsp.lua
@@ -167,7 +167,7 @@ function M.apply_user_lsp_settings(server_name)
     utils.conditional_func(old_on_attach, true, client, bufnr)
 
     -- Apply lsp_mappings to the buffer
-    local lsp_mappings = require("base.4-mappings").lsp_mappings(client, bufnr)
+    local lsp_mappings = require("base.git-ignored.mappings-colemak-dh").lsp_mappings(client, bufnr)
     if not vim.tbl_isempty(lsp_mappings.v) then
       lsp_mappings.v["<leader>l"] = { desc = utils.get_icon("ActiveLSP", 1, true) .. "LSP" }
     end

--- a/lua/lazy_snapshot.lua
+++ b/lua/lazy_snapshot.lua
@@ -10,7 +10,7 @@ return {
   { "Shatur/neovim-session-manager", commit = "df544e17798dd0e6e33ecf0991dfde9174367837" },
   { "Zeioth/NormalSnippets", commit = "e91dbace3e221ee58de39d852c93ceca166f05c3" },
   { "Zeioth/compiler.nvim", version = "^4" },
-  { "Zeioth/distroupdate.nvim", commit = "8aedd365363f82b82011934e442e2ed8f1ddc512" },
+  { "Zeioth/distroupdate.nvim", version = "^0.4" },
   { "Zeioth/dooku.nvim", version = "^2" },
   { "Zeioth/markmap.nvim", version = "^3" },
   { "Zeioth/project.nvim", commit = "3d30a4ddaf0f0c30892fb2f36fa4669499d7e6db" },

--- a/lua/plugins/1-base-behaviors.lua
+++ b/lua/plugins/1-base-behaviors.lua
@@ -654,11 +654,11 @@ return {
     dependencies = { "nvim-lua/plenary.nvim" },
     cmd = {
       "NvimChangelog",
+      "NvimDistroUpdate",
       "NvimFreezePluginVersions",
       "NvimReload",
       "NvimRollbackCreate",
       "NvimRollbackRestore",
-      "NvimUpdateConfig",
       "NvimUpdatePlugins",
       "NvimVersions"
     },

--- a/lua/plugins/1-base-behaviors.lua
+++ b/lua/plugins/1-base-behaviors.lua
@@ -656,7 +656,6 @@ return {
       "NvimChangelog",
       "NvimDistroUpdate",
       "NvimFreezePluginVersions",
-      "NvimReload",
       "NvimRollbackCreate",
       "NvimRollbackRestore",
       "NvimUpdatePlugins",


### PR DESCRIPTION
* `:NvimUpdateConfig` renamed to `NvimDistroUpdate`.
* `:NvimReload` removed, as it is now automatically managed by the option `hot_reload_files`.