### PR TITLE
This PR preprares none-ls for its new version

### DIFF
--- a/lua/base/utils/lsp.lua
+++ b/lua/base/utils/lsp.lua
@@ -173,9 +173,6 @@ function M.apply_user_lsp_settings(server_name)
     pcall(require, "neodev")
     opts.settings = { Lua = { workspace = { checkThirdParty = false } } }
   end
-  if server_name == "bashls" then -- by default use mason shellcheck path
-    opts.settings = { bashIde = { shellcheckPath = vim.fn.stdpath "data" .. "/mason/bin/shellcheck" } }
-  end
 
   -- Apply them
   local old_on_attach = server.on_attach

--- a/lua/plugins/3-dev-core.lua
+++ b/lua/plugins/3-dev-core.lua
@@ -277,23 +277,26 @@ return {
         },
         opts = { handlers = {} },
       },
-      "gbprod/none-ls-shellcheck.nvim",
+      "nvimtools/none-ls-extras.nvim",
+      "gbprod/none-ls-shellcheck.nvim"
     },
     event = "User BaseFile",
     opts = function()
       local nls = require "null-ls"
-      require("null-ls").register(require("none-ls-shellcheck.code_actions"))
+      local shellcheck_code_actions = require("none-ls-shellcheck.code_actions")
+
+      -- You can customize your formatters here.
+      nls.register(shellcheck_code_actions)
+      nls.builtins.formatting.shfmt.with({
+        command = "shfmt",
+        args = { "-i", "2", "-filename", "$FILENAME" },
+      })
+
+      -- Attach the user lsp mappings to every none-ls client.
       return {
-        sources = {
-          -- You can customize your formatters here.
-          nls.builtins.formatting.shfmt.with {
-            command = "shfmt",
-            args = { "-i", "2", "-filename", "$FILENAME" },
-          },
-        },
         on_attach = utils_lsp.apply_user_lsp_mappings,
       }
-    end,
+    end
   },
 
   --  neodev.nvim [lsp for nvim lua api]

--- a/lua/plugins/3-dev-core.lua
+++ b/lua/plugins/3-dev-core.lua
@@ -265,18 +265,26 @@ return {
   --  https://github.com/b0o/SchemaStore.nvim
   "b0o/SchemaStore.nvim",
 
+  -- mason-null-ls.nivm
+  -- https://github.com/jay-babu/mason-null-ls.nvim
+  -- Allows none-ls to use clients installed by mason.
+  {
+    "jay-babu/mason-null-ls.nvim",
+    cmd = {
+      "NullLsInstall",
+      "NullLsUninstall",
+      "NoneLsInstall",
+      "NoneLsUninstall"
+    },
+    opts = { handlers = {} },
+  },
+
   --  none-ls [lsp code formatting]
   --  https://github.com/nvimtools/none-ls.nvim
   {
     "nvimtools/none-ls.nvim",
     dependencies = {
-      {
-        "jay-babu/mason-null-ls.nvim",
-        cmd = {
-          "NullLsInstall", "NullLsUninstall", "NoneLsInstall", "NoneLsUninstall"
-        },
-        opts = { handlers = {} },
-      },
+      "jay-babu/mason-null-ls.nvim",
       "nvimtools/none-ls-extras.nvim",
       "gbprod/none-ls-shellcheck.nvim"
     },

--- a/lua/plugins/3-dev-core.lua
+++ b/lua/plugins/3-dev-core.lua
@@ -277,10 +277,12 @@ return {
         },
         opts = { handlers = {} },
       },
+      "gbprod/none-ls-shellcheck.nvim",
     },
     event = "User BaseFile",
     opts = function()
       local nls = require "null-ls"
+      require("null-ls").register(require("none-ls-shellcheck.code_actions"))
       return {
         sources = {
           -- You can customize your formatters here.
@@ -288,10 +290,6 @@ return {
             command = "shfmt",
             args = { "-i", "2", "-filename", "$FILENAME" },
           },
-          -- https://github.com/bash-lsp/bash-language-server/issues/933
-          -- TODO: Disable the next feature once this has been merged.
-          nls.builtins.code_actions.shellcheck,
-          nls.builtins.diagnostics.shellcheck.with { diagnostics_format = "" },
         },
         on_attach = utils_lsp.apply_user_lsp_mappings,
       }


### PR DESCRIPTION
* This new config is valid with both the old and the new version.
* We are not shipping the new none-ls version yet though. Let's give it a a few weeks so people have time to fix possible bugs, as they just went through a massive refactor.