### PR TITLE
♻️refactor(`none-ls`): For now `beautysh` seems support seems to have been dropped…

### DIFF
--- a/lua/plugins/3-dev-core.lua
+++ b/lua/plugins/3-dev-core.lua
@@ -285,7 +285,6 @@ return {
     "nvimtools/none-ls.nvim",
     dependencies = {
       "jay-babu/mason-null-ls.nvim",
-      "nvimtools/none-ls-extras.nvim",
       "gbprod/none-ls-shellcheck.nvim"
     },
     event = "User BaseFile",


### PR DESCRIPTION
…, so we can remove the dependency `none-ls-extras.nvim`.

* In case you didn't notice, in `NormalNvim v3.7.2`, we've moved to `shfmt` due to this..