### PR TITLE
fix(lsp): User lsp settings capabilities are now correctly applyed

### DIFF
--- a/.selene-schema.yml
+++ b/.selene-schema.yml
@@ -1,41 +1,42 @@
+---
 base: lua51+lua52
 name: .selene-schema
 globals:
   after_each:
     args:
-    - type: function
+      - type: function
   assert.equals:
     args:
-    - type: any
-    - type: any
-    - required: false
-      type: any
+      - type: any
+      - type: any
+      - required: false
+        type: any
   assert.is_not:
     any: true
   assert.same:
     args:
-    - type: any
-    - type: any
+      - type: any
+      - type: any
   assert.spy:
     args:
-    - type: any
+      - type: any
   assert.stub:
     args:
-    - type: any
+      - type: any
   assert.truthy:
     args:
-    - type: any
+      - type: any
   before_each:
     args:
-    - type: function
+      - type: function
   describe:
     args:
-    - type: string
-    - type: function
+      - type: string
+      - type: function
   it:
     args:
-    - type: string
-    - type: function
+      - type: string
+      - type: function
   jit:
     any: true
   vim:

--- a/lua/base/utils/lsp.lua
+++ b/lua/base/utils/lsp.lua
@@ -122,20 +122,6 @@ M.apply_default_lsp_settings = function()
     return not (vim.tbl_contains(disabled, client.name) or (type(filter) == "function" and not filter(client)))
   end
 
-  --- Apply the default LSP capabilities
-  M.capabilities = vim.lsp.protocol.make_client_capabilities()
-  M.capabilities.textDocument.completion.completionItem.documentationFormat = { "markdown", "plaintext" }
-  M.capabilities.textDocument.completion.completionItem.snippetSupport = true
-  M.capabilities.textDocument.completion.completionItem.preselectSupport = true
-  M.capabilities.textDocument.completion.completionItem.insertReplaceSupport = true
-  M.capabilities.textDocument.completion.completionItem.labelDetailsSupport = true
-  M.capabilities.textDocument.completion.completionItem.deprecatedSupport = true
-  M.capabilities.textDocument.completion.completionItem.commitCharactersSupport = true
-  M.capabilities.textDocument.completion.completionItem.tagSupport = { valueSet = { 1 } }
-  M.capabilities.textDocument.completion.completionItem.resolveSupport =
-  { properties = { "documentation", "detail", "additionalTextEdits" } }
-  M.capabilities.textDocument.foldingRange = { dynamicRegistration = false, lineFoldingOnly = true }
-  M.flags = {}
 end
 
 --- This function has the sole purpose of passing the lsp keymappings to lsp.
@@ -157,8 +143,23 @@ end
 function M.apply_user_lsp_settings(server_name)
   local server = require("lspconfig")[server_name]
 
-  -- Define user server rules.
+  -- Define user server capabilities.
+  M.capabilities = vim.lsp.protocol.make_client_capabilities()
+  M.capabilities.textDocument.completion.completionItem.documentationFormat = { "markdown", "plaintext" }
+  M.capabilities.textDocument.completion.completionItem.snippetSupport = true
+  M.capabilities.textDocument.completion.completionItem.preselectSupport = true
+  M.capabilities.textDocument.completion.completionItem.insertReplaceSupport = true
+  M.capabilities.textDocument.completion.completionItem.labelDetailsSupport = true
+  M.capabilities.textDocument.completion.completionItem.deprecatedSupport = true
+  M.capabilities.textDocument.completion.completionItem.commitCharactersSupport = true
+  M.capabilities.textDocument.completion.completionItem.tagSupport = { valueSet = { 1 } }
+  M.capabilities.textDocument.completion.completionItem.resolveSupport =
+  { properties = { "documentation", "detail", "additionalTextEdits" } }
+  M.capabilities.textDocument.foldingRange = { dynamicRegistration = false, lineFoldingOnly = true }
+  M.flags = {}
   local opts = utils.extend_tbl(server, { capabilities = M.capabilities, flags = M.flags })
+
+  -- Define user server rules.
   if server_name == "jsonls" then -- by default add json schemas
     local schemastore_avail, schemastore = pcall(require, "schemastore")
     if schemastore_avail then


### PR DESCRIPTION
This is a minor fix that affect mostly to the yamlls fix we were supposed to be applying.

After this commit, the yamlls lsp server won't show warnings anymore.