### PR TITLE
🐛fix(`luasnip`): Now install jsregexp correctly on UNIX.

### DIFF
--- a/lua/plugins/4-dev.lua
+++ b/lua/plugins/4-dev.lua
@@ -68,7 +68,7 @@ return {
   --  https://github.com/rafamadriz/friendly-snippets
   {
     "L3MON4D3/LuaSnip",
-    build = vim.fn.has "win32" ~= 0 and "make install_jsregexp" or nil,
+    build = not is_windows and "make install_jsregexp" or nil,
     dependencies = {
       "rafamadriz/friendly-snippets",
       "Zeioth/NormalSnippets",


### PR DESCRIPTION
This improves the way luasnip work.