### PR TITLE
fix(`android OS detection`): osx was erronously detected as android b…

### DIFF
--- a/lua/base/1-options.lua
+++ b/lua/base/1-options.lua
@@ -66,7 +66,7 @@ vim.opt.shortmess:append { s = true, I = true } -- Disable startup message.
 vim.opt.backspace:append { "nostop" } -- Don't stop backspace at insert.
 vim.opt.diffopt:append { "algorithm:histogram", "linematch:60" } -- Enable linematch diff algorithm
 
-local is_android = vim.fn.isdirectory('/system') == 1
+local is_android = vim.fn.isdirectory('/data') == 1
 if is_android then vim.opt.mouse = "v" else vim.opt.mouse = "a" end -- Enable scroll for android
 
 -- Globals --------------------------------------------------------------------

--- a/lua/base/4-mappings.lua
+++ b/lua/base/4-mappings.lua
@@ -61,7 +61,7 @@ local get_icon = utils.get_icon
 local is_available = utils.is_available
 local ui = require "base.utils.ui"
 local maps = require("base.utils").get_mappings_template()
-local is_android = vim.fn.isdirectory('/system') == 1   -- true if on android
+local is_android = vim.fn.isdirectory('/data') == 1 -- true if on android
 
 -- -------------------------------------------------------------------------
 --

--- a/lua/plugins/1-base-behaviors.lua
+++ b/lua/plugins/1-base-behaviors.lua
@@ -23,8 +23,8 @@
 --       -> lsp_signature.nvim     [auto params help]
 --       -> distroupdate.nvim      [distro update]
 
-local is_windows = vim.fn.has('win32') == 1             -- true if on windows
-local is_android = vim.fn.isdirectory('/system') == 1   -- true if on android
+local is_windows = vim.fn.has('win32') == 1         -- true if on windows
+local is_android = vim.fn.isdirectory('/data') == 1 -- true if on android
 
 return {
   -- [ranger] file browser

--- a/lua/plugins/2-ui.lua
+++ b/lua/plugins/2-ui.lua
@@ -22,8 +22,8 @@
 --       -> which-key                   [on-screen keybinding]
 
 local utils = require "base.utils"
-local is_windows = vim.fn.has('win32') == 1             -- true if on windows
-local is_android = vim.fn.isdirectory('/system') == 1   -- true if on android
+local is_windows = vim.fn.has('win32') == 1         -- true if on windows
+local is_android = vim.fn.isdirectory('/data') == 1 -- true if on android
 
 return {
 


### PR DESCRIPTION
…ecause both have the directory "/system". Fixes #373.