### PR TITLE
fix(`markdown-preview.nvim`): It is necessay to enable by filetype fo…

### DIFF
--- a/lua/plugins/4-dev.lua
+++ b/lua/plugins/4-dev.lua
@@ -248,7 +248,8 @@ return {
   --  Note: If you change the build command, wipe ~/.local/data/nvim/lazy
   {
     "iamcco/markdown-preview.nvim",
-    build = "cd app && yarn install",
+    build = function() vim.fn["mkdp#util#install"]() end,
+    ft = { "markdown" },
     cmd = {
       "MarkdownPreview",
       "MarkdownPreviewStop",


### PR DESCRIPTION
…r this plugin.

Also it is not necessary to use yarn/npm for the installation anymore.