### PR TITLE
🐛fix(`:CoverageSummary`): Don't show `mini-indent.nvim` anymore.

### DIFF
--- a/lua/plugins/2-ui.lua
+++ b/lua/plugins/2-ui.lua
@@ -276,7 +276,8 @@ return {
             "startify",
             "toggleterm",
             "Trouble",
-            "calltree"
+            "calltree",
+            "coverage"
           }
           if vim.tbl_contains(ignored_filetypes, vim.bo.filetype) then
             vim.b.miniindentscope_disable = true


### PR DESCRIPTION
![screenshot_2024-04-29_22-15-45_889880935](https://github.com/NormalNvim/NormalNvim/assets/3357792/89d50374-5565-4e28-870e-2fb714868b1b)