### PR TITLE
✨feat(nvim-coverage): New mapping Space + T + C to toggle code coverage signs.

### DIFF
--- a/lua/base/4-mappings.lua
+++ b/lua/base/4-mappings.lua
@@ -1222,14 +1222,16 @@ end
 if is_available "nvim-coverage" then
   maps.n["<leader>Tc"] = {
     function()
-      utils.notify(
-        "Attempting to find coverage/lcov.info in project root...",
-        vim.log.levels.INFO
-      )
       require("coverage").load(false)
       require("coverage").summary()
     end,
     desc = "Coverage",
+  }
+  maps.n["<leader>TC"] = {
+    function()
+      ui.toggle_coverage_signs()
+    end,
+    desc = "Coverage signs (toggle)",
   }
 end
 

--- a/lua/base/utils/ui.lua
+++ b/lua/base/utils/ui.lua
@@ -16,6 +16,7 @@
 --      -> toggle_buffer_semantic_tokens
 --      -> toggle_buffer_syntax
 --      -> toggle_codelens
+--      -> toggle_coverage_signs
 --      -> toggle_cmp
 --      -> toggle_conceal
 --      -> toggle_diagnostics
@@ -162,6 +163,23 @@ function M.toggle_codelens()
   vim.g.codelens_enabled = not vim.g.codelens_enabled
   if not vim.g.codelens_enabled then vim.lsp.codelens.clear() end
   utils.notify(string.format("CodeLens %s", bool2str(vim.g.codelens_enabled)))
+end
+
+--- Toggle coverage signs
+function M.toggle_coverage_signs(bufnr)
+  bufnr = bufnr or 0
+  vim.b[bufnr].coverage_signs_enabled = not vim.b[bufnr].coverage_signs_enabled
+  if vim.b[bufnr].coverage_signs_enabled then
+    utils.notify("Coverage signs on:" ..
+                 "\n\n- Git signs will be temporary disabled." ..
+                 "\n- Diagnostic signs won't be automatically disabled.")
+    vim.cmd("Gitsigns toggle_signs")
+    require("coverage").load(true)
+  else
+    utils.notify("Coverage signs off:\n\n- Git signs re-enabled.")
+    require("coverage").hide()
+    vim.cmd("Gitsigns toggle_signs")
+  end
 end
 
 --- Toggle cmp entrirely

--- a/lua/plugins/4-dev.lua
+++ b/lua/plugins/4-dev.lua
@@ -895,7 +895,12 @@ return {
       "CoverageSummary",
     },
     dependencies = { "nvim-lua/plenary.nvim" },
-    config = function() require("coverage").setup() end,
+    opts = {
+      summary = {
+        min_coverage = 80.0, -- passes if higher than
+      },
+    },
+    config = function(_, opts) require("coverage").setup(opts) end,
   },
 
   -- LANGUAGE IMPROVEMENTS ----------------------------------------------------


### PR DESCRIPTION
* It marks the lines of the current buffer that are not covered by tests yet.
* This makes super easy to figure out the lines where you are missing code coverage in your code.

![screenshot_2024-04-30_01-04-36_605618825](https://github.com/NormalNvim/NormalNvim/assets/3357792/a77fb717-ffc1-4a80-8877-af2686490688)
