### PR TITLE
🐛fix(`treesitter`): Has unusable performance on `C` when t…

### DIFF
--- a/lua/plugins/3-dev-core.lua
+++ b/lua/plugins/3-dev-core.lua
@@ -69,7 +69,11 @@ return {
       matchup = {
         enable = true,
         enable_quotes = true,
-        disable = function(_, bufnr) return utils.is_big_file(bufnr) end,
+        disable = function(_, bufnr)
+          local excluded_filetypes = { "c" } -- disable for slow parsers
+          local is_disabled = excluded_filetypes or utils.is_big_file(bufnr)
+          return is_disabled
+        end,
       },
       incremental_selection = { enable = true },
       indent = { enable = true },


### PR DESCRIPTION
…he feature `matchup` is enabled. So let's disable it for now for `C`.