### PR TITLE
fix(heirline `lib.component.compiler_build_type()`): displaying on neotree/terminal/telescope

### DIFF
--- a/lua/base/1-options.lua
+++ b/lua/base/1-options.lua
@@ -26,8 +26,8 @@ vim.opt.foldcolumn = "1" -- Show foldcolumn in nvim 0.9+.
 vim.opt.ignorecase = true -- Case insensitive searching.
 vim.opt.infercase = true -- Infer cases in keyword completion.
 
-vim.opt.laststatus = 3 -- Globalstatus.
-vim.opt.linebreak = true -- Wrap lines at'breakat'.
+vim.opt.laststatus = 3 -- Global statusline.
+vim.opt.linebreak = true -- Wrap lines at 'breakat'.
 vim.opt.number = true -- Show numberline.
 vim.opt.preserveindent = true -- Preserve indent structure as much as possible.
 vim.opt.pumheight = 10 -- Height of the pop up menu.

--- a/lua/plugins/2-ui.lua
+++ b/lua/plugins/2-ui.lua
@@ -335,7 +335,6 @@ return {
               lib.component.neotree(),
               lib.component.compiler_play(),
               lib.component.fill(),
-              lib.component.compiler_build_type(),
               lib.component.compiler_redo(),
               lib.component.aerial(),
             },


### PR DESCRIPTION
We forgot to delele `lib.component.compiler_build_type()` from the inactive winbar. So it was displaying in border cases in C and Java.

There is a 99% chance you never encountered this bug, but it's gone now anyway.