### PR TITLE
🐛fix(`yazi.nvim`): `use_yazi_client_id_flag` requires yazi-git so let…

### DIFF
--- a/lua/plugins/1-base-behaviors.lua
+++ b/lua/plugins/1-base-behaviors.lua
@@ -38,7 +38,7 @@ return {
     opts = {
         open_for_directories = true,
         use_ya_for_events_reading = true,
-        use_yazi_client_id_flag = true,
+        use_yazi_client_id_flag = false, -- enable once yazi v0.4.0 is released
         floating_window_scaling_factor = (is_android and 1.0) or 0.71
     },
   },


### PR DESCRIPTION
…'s disable it for now as this option is there for adding yazi session resume in the future once `yazi.nvim` implements it.