### PR TITLE
fix(yazi): use new yazi commands

### DIFF
--- a/lua/plugins/1-base-behaviors.lua
+++ b/lua/plugins/1-base-behaviors.lua
@@ -34,7 +34,7 @@ return {
   {
     "mikavilpas/yazi.nvim",
     event = "User BaseDefered",
-    cmd = { "Yazi", "YaziCWD", "YaziToggle" },
+    cmd = { "Yazi", "Yazi cwd", "Yazi toggle" },
     opts = {
         open_for_directories = true,
         use_ya_for_events_reading = true,


### PR DESCRIPTION
In https://github.com/mikavilpas/yazi.nvim/pull/320, the commands were changed to scoped commands starting with `Yazi`. This commit updates the commands in the base behaviors plugin to use the new commands.