### PR TITLE
♻️fix(`nvim-ts-autopairs`): Has been moved to `1-base-behaviors.lua`

### DIFF
--- a/lua/lazy_snapshot.lua
+++ b/lua/lazy_snapshot.lua
@@ -97,7 +97,7 @@ return {
   { "williamboman/mason-lspconfig.nvim", version = "^2" },
   { "williamboman/mason.nvim", version = "^2" },
   { "windwp/nvim-autopairs", commit = "e38c5d837e755ce186ae51d2c48e1b387c4425c6" },
-  { "windwp/nvim-ts-autotag", commit = "dc5e1687ab76ee02e0f11c5ce137f530b36e98b3" },
+  { "windwp/nvim-ts-autotag", commit = "0cb76eea80e9c73b88880f0ca78fbd04c5bdcac7" },
   { "zeioth/NormalSnippets", commit = "ef841ad4a0ccc6144d605cd2b4a874b04b295cb8" },
   { "zeioth/compiler.nvim", version = "^4" },
   { "zeioth/distroupdate.nvim", version = "^1" },

--- a/lua/plugins/1-base-behaviors.lua
+++ b/lua/plugins/1-base-behaviors.lua
@@ -20,6 +20,7 @@
 --       -> vim-matchup            [Improved % motion]
 --       -> hop.nvim               [go to word visually]
 --       -> nvim-autopairs         [auto close brackets]
+--       -> nvim-ts-autotag        [auto close html tags]
 --       -> lsp_signature.nvim     [auto params help]
 --       -> nvim-lightbulb         [lightbulb for code actions]
 --       -> distroupdate.nvim      [distro update]
@@ -573,6 +574,7 @@ return {
   {
     "windwp/nvim-autopairs",
     event = "InsertEnter",
+    dependencies = "windwp/nvim-ts-autotag",
     opts = {
       check_ts = true,
       ts_config = { java = false },
@@ -602,6 +604,19 @@ return {
         )
       end
     end
+  },
+
+  -- nvim-ts-autotag [auto close html tags]
+  -- https://github.com/windwp/nvim-ts-autotag
+  -- Adds support for HTML tags to the plugin nvim-autopairs.
+  {
+    "windwp/nvim-ts-autotag",
+    event = "InsertEnter",
+    dependencies = {
+      "nvim-treesitter/nvim-treesitter",
+      "windwp/nvim-autopairs"
+    },
+    opts = {}
   },
 
   -- lsp_signature.nvim [auto params help]

--- a/lua/plugins/3-dev-core.lua
+++ b/lua/plugins/3-dev-core.lua
@@ -4,7 +4,6 @@
 --    Sections:
 --       ## TREE SITTER
 --       -> nvim-treesitter                [syntax highlight]
---       -> nvim-ts-autotag                [treesitter understand html tags]
 --       -> ts-comments.nvim               [treesitter comments]
 --       -> render-markdown.nvim           [normal mode markdown]
 --       -> nvim-highlight-colors          [hex colors]
@@ -34,14 +33,10 @@ return {
   --  TREE SITTER ---------------------------------------------------------
   --  [syntax highlight] + [treesitter understand html tags] + [comments]
   --  https://github.com/nvim-treesitter/nvim-treesitter
-  --  https://github.com/windwp/nvim-ts-autotag
   --  https://github.com/windwp/nvim-treesitter-textobjects
   {
     "nvim-treesitter/nvim-treesitter",
-    dependencies = {
-      "windwp/nvim-ts-autotag",
-      "nvim-treesitter/nvim-treesitter-textobjects",
-    },
+    dependencies = { "nvim-treesitter/nvim-treesitter-textobjects" },
     event = "User BaseDefered",
     cmd = {
       "TSBufDisable",


### PR DESCRIPTION
…as it is esentially HTML support for the plugin `autopairs`.

Also, we now use the correct lazy event.