### PR TITLE
♻️refactor(comments): Replace all `vim.loop` by `vim.uv`.

### DIFF
--- a/lua/base/3-autocmds.lua
+++ b/lua/base/3-autocmds.lua
@@ -192,7 +192,7 @@ autocmd("BufWritePre", {
 
     if buf_is_valid_and_listed then
       vim.fn.mkdir(vim.fn.fnamemodify(
-        vim.loop.fs_realpath(args.match) or args.match, ":p:h"), "p")
+        vim.uv.fs_realpath(args.match) or args.match, ":p:h"), "p")
     end
   end,
 })

--- a/lua/plugins/3-dev-core.lua
+++ b/lua/plugins/3-dev-core.lua
@@ -272,6 +272,7 @@ return {
 
   --  Schema Store [mason extra schemas]
   --  https://github.com/b0o/SchemaStore.nvim
+  --  We use this plugin in ../base/utils/lsp.lua
   "b0o/SchemaStore.nvim",
 
   -- none-ls-autoload.nvim [mason package loader]

--- a/lua/plugins/4-dev.lua
+++ b/lua/plugins/4-dev.lua
@@ -87,7 +87,7 @@ return {
   --  https://github.com/lewis6991/gitsigns.nvim
   {
     "lewis6991/gitsigns.nvim",
-    enabled = vim.fn.executable "git" == 1,
+    enabled = vim.fn.executable("git") == 1,
     event = "User BaseGitFile",
     opts = function()
       local get_icon = require("base.utils").get_icon
@@ -120,7 +120,7 @@ return {
   --  	keepBackup = false
   {
     "tpope/vim-fugitive",
-    enabled = vim.fn.executable "git" == 1,
+    enabled = vim.fn.executable("git") == 1,
     dependencies = { "tpope/vim-rhubarb" },
     cmd = {
       "Gvdiffsplit",
@@ -139,7 +139,7 @@ return {
       "Gstatus",
     },
     config = function()
-      -- NOTE: On vimplugins we use config instead of opts.
+      -- NOTE: On vim plugins we use config instead of opts.
       vim.g.fugitive_no_maps = 1
     end,
   },


### PR DESCRIPTION
Nvim 0.9 legacy code was already removed in previous versions. This is just a line we forgot to delete.