### PR TITLE
♻️refactor(`vim.highlight`): is going to be deprecated.

### DIFF
--- a/lua/plugins/2-ui.lua
+++ b/lua/plugins/2-ui.lua
@@ -691,7 +691,7 @@ return {
       vim.api.nvim_create_autocmd("TextYankPost", {
         desc = "Highlight yanked text",
         pattern = "*",
-        callback = function() vim.highlight.on_yank() end,
+        callback = function() vim.hl.on_yank() end,
       })
     end,
   },


### PR DESCRIPTION
From now on we use `vim.hl` instead.