### PR TITLE
🐛fix(`0.11 deprecation`): This is the new way 0.11 want us to define …

### DIFF
--- a/lua/base/4-mappings.lua
+++ b/lua/base/4-mappings.lua
@@ -1543,20 +1543,22 @@ if is_autoformat_enabled and is_filetype_allowed and is_filetype_ignored then
 
   -- Goto help
   lsp_mappings.n["gh"] = {
-    function() vim.lsp.buf.hover() end,
+    function()
+      vim.lsp.buf.hover(require("base.utils.lsp").lsp_hover_config)
+    end,
     desc = "Hover help",
   }
   lsp_mappings.n["gH"] = {
-    function() vim.lsp.buf.signature_help() end,
+    function() vim.lsp.buf.signature_help(require("base.utils.lsp").lsp_hover_config) end,
     desc = "Signature help",
   }
 
   lsp_mappings.n["<leader>lh"] = {
-    function() vim.lsp.buf.hover() end,
+    function() vim.lsp.buf.hover(require("base.utils.lsp").lsp_hover_config) end,
     desc = "Hover help",
   }
   lsp_mappings.n["<leader>lH"] = {
-    function() vim.lsp.buf.signature_help() end,
+    function() vim.lsp.buf.signature_help(require("base.utils.lsp").lsp_hover_config) end,
     desc = "Signature help",
   }
 

--- a/lua/base/utils/lsp.lua
+++ b/lua/base/utils/lsp.lua
@@ -40,9 +40,10 @@ M.apply_default_lsp_settings = function()
     vim.fn.sign_define(sign.name, sign)
   end
 
-  -- Borders
-  -- Apply the option lsp_round_borders_enabled from ../1-options.lua
-  if vim.g.lsp_round_borders_enabled then
+  -- Apply default lsp hover borders
+  -- Applies the option lsp_round_borders_enabled from ../1-options.lua
+  M.lsp_hover_config = vim.g.lsp_round_borders_enabled and { border = "rounded", silent = true } or {}
+  if vim.fn.has("nvim-0.11") == 0 then -- TODO: Delete when dropping 0.10 support
     vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, { border = "rounded", silent = true })
     vim.lsp.handlers["textDocument/signatureHelp"] =
         vim.lsp.with(vim.lsp.handlers.signature_help, { border = "rounded", silent = true })


### PR DESCRIPTION
…lsp hover borders.