### PR TITLE
🐛fix(`checkhealth base`): Running the command without having `git` in…

### DIFF
--- a/lua/base/health.lua
+++ b/lua/base/health.lua
@@ -10,6 +10,7 @@ function M.check()
   local success, git_utils = pcall(require, "distroupdate.utils.git")
   local distroupdate_config = vim.g.distroupdate_config or {}
   local normalnvim_version = "unknown"
+  success = (success and vim.fn.executable("git") == 1)
 
   if success then normalnvim_version = git_utils.current_version(false) end
   if distroupdate_config.branch == "nightly" then


### PR DESCRIPTION
…stalled, was causing an error.

This bug was exclusive of users who downloaded the distro manualyl, instead of cloning. Good catch!