### PR TITLE
# docs: Update README.md to include cloning instructions for PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,16 @@ git clone https://github.com/NormalNvim/NormalNvim.git ~/.config/nvim
 ```
 
 ### Clone manually (Windows)
+#### Command Prompt
 ```sh
 # Strongly recommended: Fork the repo and clone YOUR fork.
 git clone https://github.com/NormalNvim/NormalNvim.git %USERPROFILE%\AppData\Local\nvim && nvim
+```
+
+#### Powershell
+```sh
+# Strongly recommended: Fork the repo and clone YOUR fork.
+git clone https://github.com/NormalNvim/NormalNvim.git $env:LOCALAPPDATA\nvim && nvim
 ```
 
 ### Optional dependencies


### PR DESCRIPTION
### Context
While trying to install NormalNvim on Windows using PowerShell, I noticed that the current installation command only works in Command Prompt. I thought it would be helpful to provide instructions for PowerShell users to make the installation process more seamless.

### Changes
- Added a dedicated PowerShell section under Windows installation instructions
- Added PowerShell-compatible installation command using `$env:LOCALAPPDATA`
- Organized Windows instructions into clear subsections for different shells

The Windows installation section now includes both:

```sh
# Command Prompt
git clone https://github.com/NormalNvim/NormalNvim.git %USERPROFILE%\AppData\Local\nvim && nvim

# PowerShell
git clone https://github.com/NormalNvim/NormalNvim.git $env:LOCALAPPDATA\nvim && nvim
```

This makes it easier for Windows users to install NormalNvim using their preferred shell.

---
Please let me know if any adjustments are needed!