### PR TITLE
fixn(vim-java): order seem to matter now for mason registries.

### DIFF
--- a/lua/plugins/3-dev-core.lua
+++ b/lua/plugins/3-dev-core.lua
@@ -248,8 +248,8 @@ return {
     },
     opts = {
       registries = {
-        "github:nvim-java/mason-registry",
         "github:mason-org/mason-registry",
+        "github:nvim-java/mason-registry",
       },
       ui = {
         icons = {
@@ -624,3 +624,4 @@ return {
   },
 
 }
+


### PR DESCRIPTION
Otherwise the mason regristries directory might not be created correctly.