### PR TITLE
cleanup: all cmp plugins are installed as dependencies of nvim-cmp in…

### DIFF
--- a/lua/plugins/4-dev.lua
+++ b/lua/plugins/4-dev.lua
@@ -350,12 +350,6 @@ return {
     event = "User BaseFile",
     opts = {},
   },
-  -- copilot-cmp
-  -- https://github.com/zbirenbaum/copilot-cmp
-  {
-    "zbirenbaum/copilot-cmp",
-     opts = {}
-  },
 
   -- [guess-indent]
   -- https://github.com/NMAC427/guess-indent.nvim


### PR DESCRIPTION
… the file `3-dev-core.lua`, so let's keep it there and clean `4-dev.lua`.