### PR TITLE
fix(mappings): can't open home page when more than one window opened

### DIFF
--- a/lua/base/4-mappings.lua
+++ b/lua/base/4-mappings.lua
@@ -561,7 +561,7 @@ if is_available("alpha-nvim") then
     function()
       local wins = vim.api.nvim_tabpage_list_wins(0)
       if #wins > 1
-          and vim.api.nvim_get_option_value("filetype", { win = wins[1] })
+          and vim.api.nvim_get_option_value("filetype", {})
           == "neo-tree"
       then
         vim.fn.win_gotoid(wins[2]) -- go to non-neo-tree window to toggle alpha


### PR DESCRIPTION
The `filetype` option is buffer local, so we should omit the win option.